### PR TITLE
button class override for submit button

### DIFF
--- a/source/directives/submit-button.js
+++ b/source/directives/submit-button.js
@@ -5,7 +5,7 @@
  * @description
  * Displays a submit &lt;button&gt; component that is automatically disabled when a form is invalid or in the process of submitting.
  *
- * @param {String} class Optional CSS class names to apply to button component.
+ * @param {String} buttonClass Optional CSS class names to apply to button component.
  * @param {Boolean} disable Disable button.
  * (Note the name is disable and not disabled to avoid collisions with the HTML5 disabled attribute).
  * @param {String} icon Optional CSS class to display as a button icon.
@@ -34,7 +34,7 @@ angular.module('formFor').directive('submitButton',
         label: '@'
       },
       link: function($scope, $element, $attributes, formForController) {
-        $scope['class'] = $attributes['class'];
+        $scope['buttonClass'] = $attributes.buttonClass;
 
         $scope.$watch('label', function(value) {
           $scope.bindableLabel = $sce.trustAsHtml(value);

--- a/templates/submit-button.html
+++ b/templates/submit-button.html
@@ -1,4 +1,4 @@
-<button class="btn btn-default submit-button" ng-disabled="disable || disabledByForm">
+<button class="submit-button" ng-class="buttonClass || 'btn btn-default'" ng-disabled="disable || disabledByForm">
   <i ng-if="icon" class="submit-button-icon" ng-class="icon"></i>
 
   <span ng-bind-html="bindableLabel"></span>


### PR DESCRIPTION
Docs indicate that you should be able to set `class` on the submit-button directive, but this doesn't work as expected since the element always has the `btn btn-default` classes attached. Note the attribute name change to `button-class` in order to avoid accidentally assigning the class to the container object (it should be applied to the button element in the template).
