### PR TITLE
Do not duplicate id attributes

### DIFF
--- a/templates/bootstrap/select-field.html
+++ b/templates/bootstrap/select-field.html
@@ -17,7 +17,7 @@
   <!-- Filtered dropdowns use a type-ahead style component -->
   <div ng-show="enableFiltering" class="input-group">
     <input  aria-manager
-            id="{{model.uid}}"
+            id="{{model.uid}}-filter"
             type="search" class="form-control filter-text-input"
             tabindex="{{tabIndex}}"
             placeholder="{{placeholder}}"

--- a/templates/default/select-field.html
+++ b/templates/default/select-field.html
@@ -11,7 +11,7 @@
 
   <!-- Unfiltered dropdowns use a regular <select> -->
   <select ng-if="!enableFiltering" aria-manager
-          id="{{model.uid}}"
+          id="{{model.uid}}-filter"
           class="select-field-select"
           tabindex="{{tabIndex}}"
           placeholder="{{placeholder}}"


### PR DESCRIPTION
#57 introduced the `uid` attribute. When using it on select fields, we get duplicate ids. This fixes the issue.
